### PR TITLE
H2 をレンダリングできるようにした

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -22,6 +22,7 @@ fn should_create_new_box(kind: &NodeKind) -> bool {
             | ElementKind::Style
             | ElementKind::Script
             | ElementKind::H1
+            | ElementKind::H2
             | ElementKind::P => false,
             // TODO: correct?
             ElementKind::Li | ElementKind::Ul => true,
@@ -40,6 +41,7 @@ fn paint_render_object(obj: &Rc<RefCell<RenderObject>>, content_area: &Box) {
             | ElementKind::Style
             | ElementKind::Script
             | ElementKind::H1
+            | ElementKind::H2
             | ElementKind::P
             | ElementKind::Body => {}
             ElementKind::Li => {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -154,6 +154,10 @@ fn paint_render_object(obj: &Rc<RefCell<RenderObject>>, content_area: &Box) {
                 markup_attrs.push_str(&format!("size=\"xx-large\""));
             }
 
+            if obj.borrow().style.font_size() == FontSize::XLarge {
+                markup_attrs.push_str(&format!("size=\"x-large\""));
+            }
+
             // TODO: investigate why this needs.
             label.set_xalign(0.0);
 

--- a/src/renderer/html/dom.rs
+++ b/src/renderer/html/dom.rs
@@ -117,6 +117,8 @@ impl Element {
             ElementKind::Body
         } else if name == "h1" {
             ElementKind::H1
+        } else if name == "h2" {
+            ElementKind::H2
         } else if name == "p" {
             ElementKind::P
         } else if name == "ul" {
@@ -146,6 +148,8 @@ impl Element {
             "body".to_string()
         } else if kind == ElementKind::H1 {
             "h1".to_string()
+        } else if kind == ElementKind::H2 {
+            "h2".to_string()
         } else if kind == ElementKind::P {
             "p".to_string()
         } else if kind == ElementKind::Ul {
@@ -185,6 +189,7 @@ pub enum ElementKind {
     Body,
     /// https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements
     H1,
+    H2,
     /// https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element
     P,
     /// https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element
@@ -571,6 +576,11 @@ impl HtmlParser {
                                 token = self.t.next();
                                 continue;
                             }
+                            if tag == "h2" {
+                                self.insert_element(tag, attributes.to_vec());
+                                token = self.t.next();
+                                continue;
+                            }
                             if tag == "p" {
                                 self.insert_element(tag, attributes.to_vec());
                                 token = self.t.next();
@@ -627,6 +637,11 @@ impl HtmlParser {
                             if tag == "h1" {
                                 token = self.t.next();
                                 self.pop_until(ElementKind::H1);
+                                continue;
+                            }
+                            if tag == "h2" {
+                                token = self.t.next();
+                                self.pop_until(ElementKind::H2);
                                 continue;
                             }
                             if tag == "p" {

--- a/src/renderer/layout/render_tree.rs
+++ b/src/renderer/layout/render_tree.rs
@@ -44,6 +44,7 @@ impl RenderStyle {
                 | ElementKind::Ul
                 | ElementKind::Li
                 | ElementKind::H1
+                | ElementKind::H2
                 | ElementKind::P => DisplayType::Block,
                 ElementKind::Script | ElementKind::Head | ElementKind::Style => {
                     DisplayType::DisplayNone
@@ -57,7 +58,9 @@ impl RenderStyle {
     fn default_font_size(node: &Rc<RefCell<Node>>) -> Option<FontSize> {
         match &node.borrow().kind() {
             NodeKind::Element(element) => match element.kind() {
+                // ref: [CSS Fonts Module Level 4](https://www.w3.org/TR/css-fonts-4/#absolute-size-mapping)
                 ElementKind::H1 => Some(FontSize::XXLarge),
+                ElementKind::H2 => Some(FontSize::XLarge),
                 _ => None,
             },
             _ => None,
@@ -217,7 +220,7 @@ impl BoxInfo {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum FontSize {
     Medium,
-    _XLarge,
+    XLarge,
     XXLarge,
 }
 


### PR DESCRIPTION
必須課題1である「[vulbr](https://github.com/d0iasm/vulbr)または自作のブラウザ上で `<h2>` タグを表示できるようにしてください。」の実装 PR。

h1 の実装と [CSS Fonts Module Level 4](https://www.w3.org/TR/css-fonts-4/#absolute-size-mapping) を参考に h2 を `x-large` のサイズとしてレンダリングできるようにした。